### PR TITLE
Fix conflicting functions or builds property

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,6 @@
       "dest": "/$1"
     }
   ],
-  "functions": {},
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Remove `functions` property from `vercel.json` to resolve conflict with `builds` property.

The `functions` and `builds` properties cannot be used together in Vercel configuration. As this project is a static site and the `functions` property was empty, it was removed to ensure proper deployment using the `builds` configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b0d3261-ed4d-4b80-aaa9-4f3713be4d7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b0d3261-ed4d-4b80-aaa9-4f3713be4d7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>